### PR TITLE
Use a valid deployment target for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "ROX",
     platforms: [
-        .iOS(.v8), .tvOS(.v10)
+        .iOS(.v9), .tvOS(.v10)
     ],
     products: [
         .library(
@@ -18,4 +18,5 @@ let package = Package(
             name: "ROXCore",
             path: "ROXCore.xcframework"
         )
-    ])
+    ]
+)


### PR DESCRIPTION
Swift Packages require a deployment target of iOS 9 or above but this package is currently set to iOS 8 which causes a warning.

![image](https://user-images.githubusercontent.com/706048/181066575-01926992-ad38-46e3-8912-75a8e82d5e9f.png)